### PR TITLE
fix: Sonnet indicator showing 100% instead of real % (#5)

### DIFF
--- a/src/usage.js
+++ b/src/usage.js
@@ -131,7 +131,7 @@ function normalize(raw, meta = {}) {
     limits.push({
       id: key,
       label: prettyLabel(key),
-      utilization: clamp(utilization > 1 ? utilization : utilization * 100, 0, 100),
+      utilization: clamp(utilization, 0, 100),
       resetsAt: value.resets_at || value.resetsAt || value.reset_at || null,
       windowMs: WINDOW_MS[key] || null,
     });

--- a/tests/normalize.test.js
+++ b/tests/normalize.test.js
@@ -53,9 +53,12 @@ test('normalize clamps utilization to 0..100 and preserves windowMs for known id
   assert.equal(sd.windowMs, 7 * 24 * 60 * 60 * 1000);
 });
 
-test('normalize accepts 0..1 utilization and rescales to percent', () => {
-  const result = normalize({ five_hour: { utilization: 0.42, resets_at: null } }, {});
-  assert.equal(result.limits[0].utilization, 42);
+test('normalize treats small utilization as a literal percent, not a 0..1 fraction', () => {
+  const result = normalize({ seven_day_sonnet: { utilization: 1, resets_at: null } }, {});
+  assert.equal(result.limits[0].utilization, 1);
+
+  const frac = normalize({ five_hour: { utilization: 0.42, resets_at: null } }, {});
+  assert.equal(frac.limits[0].utilization, 0.42);
 });
 
 test('normalize returns empty limits for empty payload, without crashing', () => {


### PR DESCRIPTION
## Fix: Sonnet indicator showing 100% instead of real %

Closes #5.

### Root cause
`src/usage.js` normalized utilization with an ambiguous heuristic:

```js
clamp(utilization > 1 ? utilization : utilization * 100, 0, 100)
```

The `/api/oauth/usage` endpoint already reports utilization as a **percentage** (0–100) — the test fixture confirms it (`50.0`, `25.0`, `12.0`, `4.5`). The heuristic assumed any value `<= 1` was a 0–1 fraction and multiplied it by 100, so a genuine **1%** Sonnet reading became **100%**. Every real value in `(0, 1]` was inflated 100×.

### Fix
Take the value at face value and just clamp for safety:

```js
utilization: clamp(utilization, 0, 100)
```

### Tests
- Replaced the test that encoded the buggy `0.42 → 42` rescale with one asserting `1 → 1` and `0.42 → 0.42`.
- Full suite passes (`56 pass / 0 fail`).

### Verification
Built the Windows app from this branch and ran it against a live account. The **Weekly · Sonnet** indicator now reads **1%**, matching Claude's own usage UI (previously pinned at 100%).