### PR TITLE
fix: widget drop shadow rendered with square corners

### DIFF
--- a/renderer/widget.css
+++ b/renderer/widget.css
@@ -29,8 +29,8 @@
    not on an ancestor. */
 .widget[data-theme="light"] {
   box-shadow:
-    0 8px 20px rgba(15, 23, 42, 0.06),
-    0 1px 3px rgba(15, 23, 42, 0.05);
+    0 6px 16px rgba(15, 23, 42, 0.07),
+    0 1px 3px rgba(15, 23, 42, 0.06);
 }
 .widget[data-theme="light"] .title {
   color: #000;
@@ -54,15 +54,17 @@ html, body {
 
 .widget {
   position: relative;
-  margin: 3px;
+  margin: 24px;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   backdrop-filter: blur(18px) saturate(140%);
   -webkit-backdrop-filter: blur(18px) saturate(140%);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.22);
   overflow: hidden;
 }
+
+.widget[data-layout="minimal"] { margin: 3px; }
 
 .widget.no-blur { background: var(--bg-solid); backdrop-filter: none; }
 

--- a/renderer/widget.js
+++ b/renderer/widget.js
@@ -41,7 +41,8 @@ function requestFit() {
   requestAnimationFrame(() => {
     pendingResize = false;
     if (!currentCfg || currentCfg.layout === 'minimal') return;
-    const h = root.offsetHeight + 6; // 3px margin top + 3px margin bottom
+    const gutter = parseFloat(getComputedStyle(root).marginTop) || 0;
+    const h = root.offsetHeight + gutter * 2;
     if (h <= 0 || h === lastSentHeight) return;
     lastSentHeight = h;
     window.api.resize?.(h);

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,11 @@ function isOnVisibleDisplay(rect) {
   return isOnAnyDisplay(rect, screen.getAllDisplays());
 }
 
+// Transparent padding the window carries around the widget so its drop shadow
+// renders in full (and rounded) instead of being clipped square at the window
+// edge. Must match the .widget margin in widget.css.
+const SHADOW_GUTTER = 24;
+
 function defaultCorner(width) {
   const { workArea } = screen.getPrimaryDisplay();
   return { x: workArea.x + workArea.width - width - 24, y: workArea.y + 24 };
@@ -49,7 +54,7 @@ function rescueWindowIfOrphaned() {
 
 function createWidget() {
   const isMinimal = cfg.layout === 'minimal';
-  const width = isMinimal ? 156 : cfg.size.width;
+  const width = isMinimal ? 156 : cfg.size.width + SHADOW_GUTTER * 2;
   const height = isMinimal ? 44 : 320;
   const fallback = defaultCorner(width);
   const savedX = cfg.position.x;
@@ -521,7 +526,7 @@ function applyConfig() {
     // ResizeObserver will fit the window to actual content on the next paint.
     const [, curH] = widgetWindow.getSize();
     const height = curH < 120 ? 320 : curH;
-    widgetWindow.setBounds({ x, y, width: cfg.size.width, height });
+    widgetWindow.setBounds({ x, y, width: cfg.size.width + SHADOW_GUTTER * 2, height });
   }
 }
 


### PR DESCRIPTION
## Fix: widget drop shadow rendered with square corners

The widget's cast shadow didn't follow the corner-radius set in Settings — it showed hard square corners regardless of the rounding.

### Root cause
The transparent window hugged the card with only a **3px gutter** (`.widget { margin: 3px }`, window sized to `content + 6px`). The card's `box-shadow` has a 28px blur, so the window bounds plus `body { overflow: hidden }` clipped the shadow into a hard rectangle — its rounded falloff was cut off square at the window edge.

### Fix
Give the window enough transparent room for the shadow to render in full (and therefore rounded):

- `renderer/widget.css`: widget gutter `3px → 24px`; shadows retuned to fit inside 24px (`0 6px 16px …`). The shadow now follows `border-radius` at every corner-radius value (including the 28px max). Minimal/pill layout keeps its 3px margin.
- `src/main.js`: new `SHADOW_GUTTER = 24`; the window is sized to `content + 2×gutter` at creation and on pill→expand.
- `renderer/widget.js`: the fit-to-content height now derives the gutter from the live margin instead of a hardcoded `6`, so it stays in sync.

### Notes
- Existing widgets shift ~21px further from their corner once on first launch (the window grew by the gutter); self-corrects on the next drag. New installs are unaffected.
- The transparent gutter catches mouse events (true before at 3px, now 24px) — the standard trade-off for a soft shadow on a transparent window.

### Verification
Rebuilt the Windows app and dragged the corner-radius slider across its full range — the drop shadow stays rounded and matches the card at every value.